### PR TITLE
Remoção dos Graficos

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/app/src/main/java/com/example/water_sentinel/HistoryDialogFragment.kt
+++ b/app/src/main/java/com/example/water_sentinel/HistoryDialogFragment.kt
@@ -63,7 +63,7 @@ class HistoryDialogFragment : DialogFragment() {
         val metricType = arguments?.getString(ARG_METRIC_TYPE) ?: return
         val title = arguments?.getString(ARG_METRIC_TITLE) ?: "Histórico"
 
-        val btnSeeDetails: Button = view.findViewById(R.id.btn_see_details)
+        /*val btnSeeDetails: Button = view.findViewById(R.id.btn_see_details)
 
         if (metricType == "percentage") {
             btnSeeDetails.visibility = View.VISIBLE
@@ -74,7 +74,7 @@ class HistoryDialogFragment : DialogFragment() {
             }
         } else {
             btnSeeDetails.visibility = View.GONE
-        }
+        }*/
 
 
         tvTitle = view.findViewById(R.id.dialog_title)

--- a/app/src/main/res/layout/dialog_history.xml
+++ b/app/src/main/res/layout/dialog_history.xml
@@ -95,7 +95,7 @@
 
     </LinearLayout>
 
-    <com.google.android.material.button.MaterialButton
+    <!--<com.google.android.material.button.MaterialButton
         android:id="@+id/btn_see_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -104,6 +104,6 @@
         app:backgroundTint="@null"
         android:textColor="@color/white"
         android:layout_gravity="end"
-        android:layout_marginTop="16dp"/>
+        android:layout_marginTop="16dp"/>-->
 
 </LinearLayout>


### PR DESCRIPTION
A funcionalidade dos gráficos não é tão interessante para a proposta do aplicativo. Talvez seja interessante para analisar dados coletados de certas sentinelas, mesmo assim, há outras ferramentas para conduzir a análise que não seja o aplicativo. Tendo em vista isso, este PR visa retirar essa funcionalidade do sistema, entretanto é desejável que não seja removido totalmente e sim que fique comentado no código-fonte até a próxima limpeza de código (caso a decisão seja por não seguir/melhorar a ideia dos gráficos).